### PR TITLE
Feature/member node

### DIFF
--- a/geth-poa/docker-compose.yml
+++ b/geth-poa/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       primev_net:
         ipv4_address: '172.29.0.100'
     ports:
-      - 60604:60601
+      - 60603:60601
     volumes:
       - geth-data-node2:/data
     profiles:
@@ -135,7 +135,7 @@ services:
       primev_net:
         ipv4_address: '172.29.0.101'
     ports:
-      - 60603:60601
+      - 60604:60601
     volumes:
       - geth-data-node3:/data
     profiles:

--- a/geth-poa/docker-compose.yml
+++ b/geth-poa/docker-compose.yml
@@ -97,9 +97,47 @@ services:
       primev_net:
         ipv4_address: '172.29.0.100'
     ports:
-      - 60603:60601
+      - 60604:60601
     volumes:
       - geth-data-node2:/data
+    profiles:
+      - settlement
+    labels:
+      com.datadoghq.ad.check_names: '["openmetrics"]'
+      com.datadoghq.ad.init_configs: '[{}]'
+      com.datadoghq.ad.instances: |
+        [
+          {
+            "openmetrics_endpoint": "http://%%host%%:6060/debug/metrics/prometheus",
+            "namespace": "geth-poa",
+            "metrics": [
+              "txpool*",
+              "trie*",
+              "system*",
+              "state*",
+              "rpc*",
+              "p2p*",
+              "eth*",
+              "chain*",
+              "clique*"
+            ]
+          }
+        ]
+
+  sl-node3:
+    build:
+      context: ..
+      dockerfile: geth-poa/Dockerfile
+    environment:
+      - GETH_NODE_TYPE=member
+      - BOOTNODE_ENDPOINT=enode://34a2a388ad31ca37f127bb9ffe93758ee711c5c2277dff6aff2e359bcf2c9509ea55034196788dbd59ed70861f523c1c03d54f1eabb2b4a5c1c129d966fe1e65@172.29.0.98:30301
+    networks:
+      primev_net:
+        ipv4_address: '172.29.0.101'
+    ports:
+      - 60603:60601
+    volumes:
+      - geth-data-node3:/data
     profiles:
       - settlement
     labels:
@@ -326,6 +364,7 @@ volumes:
   geth-data-bootnode:
   geth-data-node1:
   geth-data-node2:
+  geth-data-node3:
   geth-data-l1-bootnode:
   geth-data-l1-first-signer:
   geth-data-l1-second-signer:

--- a/geth-poa/entrypoint.sh
+++ b/geth-poa/entrypoint.sh
@@ -125,6 +125,44 @@ elif [ "$GETH_NODE_TYPE" = "signer" ]; then
 		--authrpc.vhosts="*" \
 		--txpool.accountqueue=512 \
 		--nat extip:$NODE_IP
+
+elif [ "$GETH_NODE_TYPE" = "member" ]; then
+	echo "Starting member node"
+
+	exec geth \
+		--verbosity="$VERBOSITY" \
+		--datadir="$GETH_DATA_DIR" \
+		--port 30311 \
+		--syncmode=full \
+		--gcmode=full \
+		--state.scheme=path \
+		--db.engine=pebble \
+		--http \
+		--http.corsdomain="*" \
+		--http.vhosts="*" \
+		--http.addr=0.0.0.0 \
+		--http.port="$RPC_PORT" \
+		--http.api=web3,debug,eth,txpool,net,engine \
+		--bootnodes $BOOTNODE_ENDPOINT \
+		--networkid=$CHAIN_ID \
+		--password="$GETH_DATA_DIR"/password \
+		--metrics \
+		--metrics.addr=0.0.0.0 \
+		--metrics.port=6060 \
+    		--pprof \
+    		--pprof.addr=0.0.0.0 \
+        	--pprof.port=60601 \
+		--ws \
+		--ws.addr=0.0.0.0 \
+		--ws.port="$WS_PORT" \
+		--ws.origins="*" \
+		--ws.api=debug,eth,txpool,net,engine \
+		--rpc.allow-unprotected-txs \
+		--authrpc.addr="0.0.0.0" \
+		--authrpc.port="8551" \
+		--authrpc.vhosts="*" \
+		--txpool.accountqueue=512 \
+		--nat extip:$NODE_IP
 else
 	echo "Invalid GETH_NODE_TYPE specified"
 fi


### PR DESCRIPTION
We have bootnodes and signers in our setup, but we haven't included member nodes yet. The rationale for incorporating member nodes into our testnet is twofold:

Enhanced Security: We aim to safeguard our signer nodes from public exposure in the current testnet, thereby reducing security vulnerabilities. This approach is crucial for maintaining the integrity and safety of our network.

Diverse Node Functions: Not every node in our network needs to have signing capabilities. Some nodes could be designated for specific tasks like merely transmitting transactions into the network. Alternatively, certain nodes could be configured to only monitor and listen to network transactions. This setup is particularly beneficial for block explorers, allowing them to connect to these dedicated nodes to fetch transaction data. Such an arrangement ensures that the block explorers do not impact the performance or traffic of nodes that are actively conducting transactions or the signer nodes that are responsible for block validation.

you can read about member nodes [here](https://geth.ethereum.org/docs/fundamentals/private-network) 