### PR TITLE
fix: reapply fee mechanism logic

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -454,9 +454,16 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		// are 0. This avoids a negative effectiveTip being applied to
 		// the coinbase when simulating calls.
 	} else {
-		fee := new(uint256.Int).SetUint64(st.gasUsed())
-		fee.Mul(fee, effectiveTipU256)
-		st.state.AddBalance(st.evm.Context.Coinbase, fee)
+		priorityFee := &uint256.Int{st.gasUsed()}
+		priorityFee.Mul(priorityFee, effectiveTipU256)
+		st.state.AddBalance(st.evm.Context.Coinbase, priorityFee)
+
+		baseFee := &uint256.Int{st.gasUsed()}
+		multiplier, _ := uint256.FromBig(st.evm.Context.BaseFee)
+		baseFee.Mul(baseFee, multiplier)
+
+		treasuryAccount := common.HexToAddress("0x0FD1bDBB92AF752a201A900e0E2bc68253C14b4c")
+		st.state.AddBalance(treasuryAccount, baseFee)
 	}
 
 	return &ExecutionResult{


### PR DESCRIPTION
reapplies changes from https://github.com/primevprotocol/mev-commit-geth/pull/9

Output of `test_fee.sh`:

```bash
+ echo 'Tresury balance diff: 189000'
Tresury balance diff: 189000
+ echo 'Payer balance diff: -100063000000189000'
Payer balance diff: -100063000000189000
+ echo 'Signer1 balance diff: 0'
Signer1 balance diff: 0
+ echo 'Signer2 balance diff: 63000000000000'
Signer2 balance diff: 63000000000000
+ echo 'Receiver balance diff: 100000000000000000'
Receiver balance diff: 100000000000000000
```