### PR TITLE
config: fee param cleanup

### DIFF
--- a/geth-poa/entrypoint.sh
+++ b/geth-poa/entrypoint.sh
@@ -94,7 +94,9 @@ if [ "$GETH_NODE_TYPE" = "bootnode" ]; then
 		--netrestrict $NET_RESTRICT \
 		"$NAT_FLAG" \
 		--txpool.accountqueue=512 \
-		--rpc.allow-unprotected-txs
+		--rpc.allow-unprotected-txs \
+		--miner.gasprice=1000000000 \
+		--gpo.maxprice=500000000000 \
 
 elif [ "$GETH_NODE_TYPE" = "signer" ]; then
 	echo "Starting signer node"
@@ -140,6 +142,8 @@ elif [ "$GETH_NODE_TYPE" = "signer" ]; then
 		--authrpc.port="8551" \
 		--authrpc.vhosts="*" \
 		--txpool.accountqueue=512 \
+		--miner.gasprice=1000000000 \
+		--gpo.maxprice=500000000000 \
 		"$NAT_FLAG"
 
 elif [ "$GETH_NODE_TYPE" = "member" ]; then
@@ -180,6 +184,8 @@ elif [ "$GETH_NODE_TYPE" = "member" ]; then
 		--authrpc.port="8551" \
 		--authrpc.vhosts="*" \
 		--txpool.accountqueue=512 \
+		--miner.gasprice=1000000000 \
+		--gpo.maxprice=500000000000 \
 		"$NAT_FLAG"
 else
 	echo "Invalid GETH_NODE_TYPE specified"

--- a/geth-poa/genesis.json
+++ b/geth-poa/genesis.json
@@ -60,11 +60,5 @@
       "0x57508f0B0f3426758F1f3D63ad4935a7c9383620": {
         "balance": "10000000000000000000000000000"
       }
-    },
-    "number": "0x0",
-    "gasUsed": "0x0",
-    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "baseFeePerGas": "0x3b9aca00",
-    "excessBlobGas": null,
-    "blobGasUsed": null
+    }
   }

--- a/geth-poa/local-l1/genesis.json
+++ b/geth-poa/local-l1/genesis.json
@@ -45,11 +45,5 @@
       "0x3fab184622dc19b6109349b94811493bf2a45362": {
         "balance": "10000000000000000000000"
       }
-    },
-    "number": "0x0",
-    "gasUsed": "0x0",
-    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "baseFeePerGas": "0x3b9aca00",
-    "excessBlobGas": null,
-    "blobGasUsed": null
+    }
   }


### PR DESCRIPTION
- Removes red herring values in genesis.json that do not affect gas params. 
- Explicitly sets `miner.gasprice` to [default value](https://github.com/primevprotocol/mev-commit-geth/blob/d23580c89c9c17dd1527bac04e72cd848e2e29d5/miner/miner.go#L61) value. `miner.gasprice` represents minimum priority fee from [this line](https://github.com/primevprotocol/mev-commit-geth/blob/92fe3f59842fc1dffec5e3e97b56836743137ab2/core/state_transition.go#L446). 
- Explicitly sets `gpo.maxprice` to [default value](https://github.com/primevprotocol/mev-commit-geth/blob/d23580c89c9c17dd1527bac04e72cd848e2e29d5/eth/gasprice/gasprice.go#L38), representing max priority fee that is suggested by gasPrice oracle. 